### PR TITLE
Suggestion: report description in more compact form

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -33,7 +33,14 @@ export function reportErrors(
 ): string {
   const formattedErrors = errors.map(
     ({ key, receivedValue, error, defaultUsed, defaultValue }) => {
-      const message: string[] = [`[${yellow(key)}]:`];
+      let title = `[${yellow(key)}]:`;
+
+      const desc = schemas[key]?.description;
+      if (desc) {
+        title += ` ${desc}`;
+      }
+
+      const message: string[] = [title];
 
       if (error instanceof ZodError) {
         const { formErrors, fieldErrors } = error.flatten();
@@ -77,14 +84,6 @@ export function reportErrors(
             )})`,
             2,
           ),
-        );
-      }
-
-      const desc = schemas[key]?.description;
-      if (desc) {
-        message.push("");
-        message.push(
-          `Description of [${yellow(key)}]: ${schemas[key]!.description}`,
         );
       }
 


### PR DESCRIPTION
before:

```
Error: Errors found while parsing environment:
  [AUTH0_ISSUER]:
    This field is required.
    (received undefined)
  
  Description of [AUTH0_ISSUER]: Base URL with Auth0 Domain

  [AUTH0_CLIENT_ID]:
    This field is required.
    (received undefined)
  
  Description of [AUTH0_CLIENT_ID]: Auth0 Client ID

  [AUTH0_CLIENT_SECRET]:
    This field is required.
    (received undefined)
  
  Description of [AUTH0_CLIENT_SECRET]: Auth0 client secret
```

after:

```
Error: Errors found while parsing environment:
  [AUTH0_ISSUER]: Base URL with Auth0 Domain
    This field is required.
    (received undefined)

  [AUTH0_CLIENT_ID]: Auth0 Client ID
    This field is required.
    (received undefined)

  [AUTH0_CLIENT_SECRET]: Auth0 client secret
    This field is required.
    (received undefined)
```